### PR TITLE
Make gulp an npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Didn't succeed to install it on your own? Don't waste 20min more, there you go:
 
 ```
 npm install
-gulp
+npm start
 ```
 
 ## API documentation

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/aircall/frontend-test"
   },
+  "scripts": {
+    "start": "gulp"
+  },
   "license": "MIT",
   "dependencies": {
     "express": "4.14.*"


### PR DESCRIPTION
Sometimes people don't have gulp installed globally. Using an npm script ensures that they use the gulp binary from node_modules that's installed from npm install